### PR TITLE
Fix offset of AAR contact point

### DIFF
--- a/B-1B-set.xml
+++ b/B-1B-set.xml
@@ -454,6 +454,14 @@ B-1B set file.
   <systems>
 		<refuel>
 			<type>boom</type>
+            <serviceable type="bool">true</serviceable>
+            <report-contact type="bool">true</report-contact>
+
+            <max-fuel-transfer-lbs-min>6000</max-fuel-transfer-lbs-min>
+            <contact-radius-m>8</contact-radius-m>
+            <offset-x-m>4</offset-x-m>
+            <offset-y-m>0</offset-y-m>
+            <offset-z-m>0.7</offset-z-m>
 		</refuel>
   </systems>
 

--- a/Models/B-1B.xml
+++ b/Models/B-1B.xml
@@ -15,6 +15,13 @@ more to come :-)
     <pitch-deg>0</pitch-deg>
     
   </offsets>
+  <multiplay>
+      <refuel>
+        <offset-x-m type="double">4.0</offset-x-m>
+        <offset-y-m type="double">0.0</offset-y-m>
+        <offset-z-m type="double">0.7</offset-z-m>
+      </refuel>
+  </multiplay>
   
   <!-- cockpit instruments -->
   


### PR DESCRIPTION
This PR adds `<multiplay>` to the model XML file. It does not transmit anything over MP, but just adds some static data to the property tree of any MP player that flies the B-1B.

If a player is flying a tanker and has this B-1B installed, the tanker will see the contact point position (because it was added to the property tree when the B-1B model was loaded) and can use this information to animate the refueling boom.
