### PR TITLE
Set AAR type to "boom" for refueling over MP

### DIFF
--- a/Models/B-1B.xml
+++ b/Models/B-1B.xml
@@ -68,6 +68,7 @@ more to come :-)
         <offset-x-m type="double">4.0</offset-x-m>
         <offset-y-m type="double">0.0</offset-y-m>
         <offset-z-m type="double">0.7</offset-z-m>
+        <type type="string">boom</type>
       </refuel>
   </multiplay>
   


### PR DESCRIPTION
This patch makes the B-1B compatible again with the 707 tanker, which was modified so that drogues will not attempt to track aircraft with a receptacle and the boom will not try to track aircraft with a probe.
